### PR TITLE
chore(deps): remove unused cors dependency

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-webserver",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "test application - web server",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,6 @@
   "license": "MIT",
   "dependencies": {
     "compression": "^1.7.4",
-    "cors": "^2.8.5",
     "express": "^5.0.0",
     "helmet": "^8.0.0",
     "pino-http": "^11.0.0"


### PR DESCRIPTION
## Summary

Removes the `cors` package from `app/package.json`. It was declared as a dependency but is never imported or used anywhere in the codebase - a repo-wide search returns only the manifest line. Removing it drops `cors` and its transitive dependencies from the production install and the Docker image, with no change in behaviour.

Also bumps the patch version `1.5.1` -> `1.5.2`.

## Changes
- `app/package.json`: remove the unused `cors` dependency, bump version to 1.5.2

## Testing
Verified locally:
- `npm install --omit=dev` resolves cleanly; `cors` is absent from `node_modules`
- Server boots and logs `Server is running on port 8080`
- `GET /healthz` returns `{"status":"healthy"}` (200)
- `GET /` returns the expected JSON (`Hello World!`, random number, 40-char sha1) (200)

No functional changes.
