### PR TITLE
refactor(app): migrate to ES modules and drop unused mocha

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const express = require('express');
-const http = require('http');
-const middleware = require('./middleware');
-const routes = require('./routes');
+import express from 'express';
+import http from 'node:http';
+import middleware from './middleware.js';
+import routes from './routes.js';
 
 const app = express();
 const server = http.createServer(app);

--- a/app/middleware.js
+++ b/app/middleware.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const express = require('express');
-const logging = require('pino-http');
-const compression = require('compression');
-const helmet = require('helmet');
+import express from 'express';
+import logging from 'pino-http';
+import compression from 'compression';
+import helmet from 'helmet';
 
 const middleware = [
   express.urlencoded({ extended: true }),
@@ -29,4 +27,4 @@ const middleware = [
   compression()
 ];
 
-module.exports = middleware;
+export default middleware;

--- a/app/package.json
+++ b/app/package.json
@@ -1,8 +1,9 @@
 {
   "name": "node-webserver",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "test application - web server",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Debug: no test specified\" && exit 0",
     "start": "node index.js",
@@ -39,8 +40,5 @@
   },
   "bugs": {
     "url": "https://github.com/saidsef/node-webserver/issues"
-  },
-  "devDependencies": {
-    "mocha": "^11.0.1"
   }
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,7 +1,6 @@
-'use strict';
+import express from 'express';
+import crypto from 'node:crypto';
 
-const express = require('express');
-const crypto = require('crypto');
 const router = express.Router();
 
 router.get('/healthz', (req, res) => {
@@ -26,4 +25,4 @@ router.get('*default', (req, res) => {
   });
 });
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
## Summary

Modernises the app to ES modules and removes a dead devDependency. Behaviour is unchanged.

### ES modules
- Sets `"type": "module"` in `app/package.json` and converts the three source files from `require`/`module.exports` to `import`/`export`. Keeps the `.js` extension - no `.mjs` rename, which is the correct idiom for an all-ESM app.
- Relative imports now carry their `.js` extension (`./middleware.js`, `./routes.js`), as ESM requires.
- Drops the `'use strict'` pragmas, which are redundant under ES modules (always strict).

### node: builtins
- Core modules use the `node:` protocol (`node:http`, `node:crypto`) so they cannot be shadowed by a userland package.

### Remove unused mocha
- `mocha` was the only devDependency but there are no test files and the `test` script is a stub, so it was dead weight. Node's built-in `node:test` covers future needs.

Also bumps the minor version `1.5.2` -> `1.6.0`.

## Changes
- `app/package.json`: add `"type": "module"`, remove `devDependencies` (mocha), bump to 1.6.0
- `app/index.js`, `app/middleware.js`, `app/routes.js`: CommonJS -> ESM, `node:` builtins

The explicit `http.createServer(app)` server handle is deliberately kept (useful for graceful shutdown, https/http2, or WebSockets).

## Testing
Verified locally:
- `node --check` passes for all three files as ES modules
- No `require` / `module.exports` / `'use strict'` remain; builtins use the `node:` prefix
- `npm install` succeeds; `mocha` absent from `node_modules`
- Server boots and logs `Server is running on port 8080`
- `GET /healthz` returns `{"status":"healthy"}` (200)
- `GET /` returns the expected JSON (`Hello World!`, random number, 40-char sha1) (200), confirming `node:crypto` resolves at runtime
- Response headers still carry helmet's CSP and compression's `Content-Encoding: gzip`

No functional changes.
